### PR TITLE
Don't limit the number of replacements in expandVars(...)

### DIFF
--- a/internal/engine/docker.go
+++ b/internal/engine/docker.go
@@ -323,7 +323,7 @@ func expandVars(command []string, name string) []string {
 	expanded := make([]string, len(command))
 	copy(expanded, command)
 	for i, cmd := range expanded {
-		expanded[i] = strings.Replace(cmd, ":name", name, 1)
+		expanded[i] = strings.Replace(cmd, ":name", name, -1)
 	}
 	return expanded
 }

--- a/internal/engine/docker_test.go
+++ b/internal/engine/docker_test.go
@@ -300,8 +300,9 @@ func TestDockerExec(t *testing.T) {
 func Test_expandVars(t *testing.T) {
 	const name = "codapi_01"
 	commands := map[string]string{
-		"python main.py":     "python main.py",
-		"sh create.sh :name": "sh create.sh " + name,
+		"python main.py":             "python main.py",
+		"sh create.sh :name":         "sh create.sh " + name,
+		"sh copy.sh :name new-:name": "sh copy.sh " + name + " new-" + name,
 	}
 	for cmd, want := range commands {
 		src := strings.Fields(cmd)


### PR DESCRIPTION
Example of complex command:

```json
{
  "stdin": true,
  "command": [
    "sh", "-c", "sed -e 's/a/b/g | mysql -h mysql -u:name -p:name -D :name"
   ]
}
```

