### PR TITLE
Bump GitHub action workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Setup Go
-              uses: actions/setup-go@v4
+              uses: actions/setup-go@v5
               with:
                   go-version: "stable"
 
@@ -35,7 +35,7 @@ jobs:
               run: make test build
 
             - name: Upload artifact
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: codapi
                   path: build/codapi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,15 +14,15 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Setup Go
-              uses: actions/setup-go@v4
+              uses: actions/setup-go@v5
               with:
                   go-version: "stable"
 
             - name: Release and publish
-              uses: goreleaser/goreleaser-action@v4
+              uses: goreleaser/goreleaser-action@v5
               with:
                   args: release --clean
               env:


### PR DESCRIPTION
This PR bumps GitHub action workflows to their latest versions, thus avoiding deprecation warning as shown e.g. [here](https://github.com/nalgeon/codapi/actions/runs/8224161942).