### PR TITLE
fix(engine): kill docker when timeout

### DIFF
--- a/internal/engine/docker.go
+++ b/internal/engine/docker.go
@@ -208,19 +208,6 @@ func (e *Docker) exec(box *config.Box, step *config.Step, req Request, dir strin
 	}
 
 	if err.Error() == "signal: killed" {
-		if step.Action == actionRun {
-			// we have to "docker kill" the container here, because the process
-			// inside the container is not related to the "docker run" process,
-			// and will hang forever after the "docker run" process is killed
-			go func() {
-				err = dockerKill(req.ID)
-				if err == nil {
-					logx.Debug("%s: docker kill ok", req.ID)
-				} else {
-					logx.Log("%s: docker kill failed: %v", req.ID, err)
-				}
-			}()
-		}
 		// context timeout
 		err = ErrTimeout
 		return


### PR DESCRIPTION
Hello, I found something was not expected when `docker run` timed out.

The `timeout` config is 5s (not changed)

And when send this msg, it will wait for 10s and return timeout, shouldn't it be 5s?
```bash
curl -X POST -H 'content-type: application/json' http://127.0.0.1:1313/v1/exec -d '{"sandbox": "sh"
, "command": "run", "files": {"": "sleep 10"}}'

{"id":"sh_run_b91cb5db","ok":false,"duration":10185,"stdout":"","stderr":"code execution timeout"}⏎  
```

From the log of server, which seems wait till `sleep 10` command finished.
- `23:14:28` start `docker run`
- `23:14:33` timed out (5s)
- `23:14:38` return (10s)
```bash
2024/04/25 23:14:28 [run --rm --name sh_run_b91cb5db --runtime runc --cpus 1 --memory 64m --network none --pids-limit 64 --user sandbox --read-only --volume /var/folders/fq/qvwpfh094rjcxfl1z0lv1vq80000gn/T/1693167471:/sandbox:ro --cap-drop all --ulimit nofile=96 codapi/alpine sh main.sh]
2024/04/25 23:14:33 sh_run_b91cb5db: execution timeout, killed process=91287, err=<nil>
2024/04/25 23:14:38 ✗ sh_run_b91cb5db: code execution timeout
2024/04/25 23:14:38 sh_run_b91cb5db: docker kill failed: exit status 1
```

This is the log after the change, which seems as expected.
```bash
2024/04/25 23:15:03 [run --rm --name sh_run_409031ba --runtime runc --cpus 1 --memory 64m --network none --pids-limit 64 --user sandbox --read-only --volume /var/folders/fq/qvwpfh094rjcxfl1z0lv1vq80000gn/T/839237894:/sandbox:ro --cap-drop all --ulimit nofile=96 codapi/alpine sh main.sh]
2024/04/25 23:15:08 sh_run_409031ba: execution timeout, killed process=91566, err=<nil>
2024/04/25 23:15:08 sh_run_409031ba: docker kill ok
2024/04/25 23:15:08 ✗ sh_run_409031ba: code execution timeout
```